### PR TITLE
Add timer-based scrollbar autohide. Trigger update only on line or buffer length change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ let g:sclow_hide_full_length = 1
 
 See help file for more information.
 
+### Autohiding
+
+By default the scrollbar will be shown on the screen permanently. If this behavior
+is undesirable, it is possible to automatically hide the scrollbar after a predefined
+period of inactivity.
+
+To make scrollbar disappear after 2000ms set:
+
+```vim
+let g:sclow_auto_hide = 2000
+```
 
 ## License
 

--- a/doc/sclow.txt
+++ b/doc/sclow.txt
@@ -83,6 +83,13 @@ OPTIONS							*sclow-options*
 	the first and last line of buffer are in the window.
 
 
+
+*g:sclow_auto_hide*		number	(default: 0)
+	Specify time of inactivity in milliseconds after which scrollbar
+	will disappear until cursor line or buffer length change. 0 disables
+	auto hiding.
+
+
 ==============================================================================
 ABOUT								*sclow-about*
 

--- a/plugin/sclow.vim
+++ b/plugin/sclow.vim
@@ -5,12 +5,13 @@ if exists('g:loaded_sclow')
   finish
 endif
 
+let g:sclow_auto_hide = get(g:, 'sclow_auto_hide', 0)
 
 function s:register_autocmds() abort
   augroup sclow-autocmds
     autocmd!
     autocmd BufEnter,WinEnter * call sclow#create()
-    autocmd CursorMoved,CursorMovedI,CursorHold * call sclow#update()
+    autocmd CursorMoved,CursorMovedI,TextChanged,TextChangedI * call sclow#update()
     autocmd BufLeave,WinLeave * call sclow#delete()
   augroup END
 endfunction


### PR DESCRIPTION
A timer based scrollbar autohide with option and improvements on update that prevent unneeded redraw and trigger update only if cursor moved up/down or buffer length changed.